### PR TITLE
Fix trailing whitespace in README.adoc:31 introduced by accident in <…

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -28,7 +28,7 @@ endif::[]
 
 == Acknowledgements
 
-* Based off the https://github.com/se-edu/addressbook-level4[AddressBook-Level4 project] created by the https://github.com/se-edu/[SE-EDU initiative] 
+* Based off the https://github.com/se-edu/addressbook-level4[AddressBook-Level4 project] created by the https://github.com/se-edu/[SE-EDU initiative]
 * Libraries used: https://github.com/TestFX/TestFX[TextFX], https://bitbucket.org/controlsfx/controlsfx/[ControlsFX], https://github.com/FasterXML/jackson[Jackson], https://github.com/google/guava[Guava], https://github.com/junit-team/junit5[JUnit5]
 
 == Licence : link:LICENSE[MIT]


### PR DESCRIPTION
…3e3f2c4566c103e9faaac36db95aff2c536f9a7a>